### PR TITLE
Enable mobile authentication in navbar

### DIFF
--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -243,12 +243,18 @@ const Navbar = () => {
                 Add Property
               </Link>
             )}
-            {!session && (
-              <button className="flex items-center text-white bg-gray-700 hover:bg-gray-900 hover:text-white rounded-md px-3 py-2 my-4">
-                <i className="fa-brands fa-google mr-2"></i>
-                <span>Login or Register</span>
-              </button>
-            )}
+            {!session &&
+              providers &&
+              Object.values(providers).map((provider, index) => (
+                <button
+                  key={index}
+                  onClick={() => signIn(provider.id)}
+                  className="flex items-center text-white bg-gray-700 hover:bg-gray-900 hover:text-white rounded-md px-3 py-2 my-4"
+                >
+                  <FaGoogle className="text-white mr-2" />
+                  <span>Login or Register</span>
+                </button>
+              ))}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- add sign-in handler for mobile 'Login or Register' button using NextAuth provider ID

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive configuration)


------
https://chatgpt.com/codex/tasks/task_e_689b6627c8308328b159a5033f839154